### PR TITLE
Added support for backup node interfaces on ScreenOS 6.3 cluster 

### DIFF
--- a/snmp_bulkget.c
+++ b/snmp_bulkget.c
@@ -583,7 +583,10 @@ main(int argc, char *argv[])
                         session.peername);
                 exit(EXITCODE_TIMEOUT);
             }
-            else
+            else if (status == STAT_ERROR && ss->s_snmp_errno == SNMPERR_TIMEOUT) {
+               printf("Timeout\n");
+                exit(EXITCODE_TIMEOUT);
+            } else
                 snmp_sess_perror("snmp_bulkget", ss);
             exit (2);
 
@@ -752,8 +755,8 @@ main(int argc, char *argv[])
                             break;
                         case 1: /*ifOperStatus */
                             if (vars->type == ASN_INTEGER)
-                                /* 1 is up(OK), 5 is dormant(assume OK) */
-                                interfaces[j].status = (*(vars->val.integer)==1 || *(vars->val.integer)==5)?1:0;
+                                /* 1 is up(OK), 3 is testing (assume OK), 5 is dormant(assume OK) */
+                                interfaces[j].status = (*(vars->val.integer)==1 || *(vars->val.integer)==5 || *(vars->val.integer)==3)?1:0;
                             break;
                         case 2: /* ifInOctets */
                             if (vars->type == ASN_COUNTER)


### PR DESCRIPTION
and provide additional timeout handling.

Infrequent timeouts led on our infrastructure to CRITICAL messages. This patch fixes that issue by having a deeper look at the error codes.

On a ScreenOS 6.3 Cluster, the passive node has its interfaces in "Inoperable" state. Via SNMP this shows as "Testing" or integer-wise 3. This patch assumes that the interfaces is alright if it is reporting that 3.