### PR TITLE
SLES 15.4 & GCC 7.5: Fixes on Compiler Warnings & Notes

### DIFF
--- a/snmp_bulkget.c
+++ b/snmp_bulkget.c
@@ -905,9 +905,9 @@ main(int argc, char *argv[])
                               (match_aliases_flag && !(regexec(&exclude_re, interfaces[i].alias, (size_t) 0, NULL, 0)));
             } if (status && !status2) {
                 count++;
-  #ifdef DEBUG
+#ifdef DEBUG
                 fprintf(stderr, "Interface %d (%s) matched\n", interfaces[i].index, interfaces[i].descr);
-  #endif
+#endif
             } else
                 interfaces[i].ignore = 1;
         }
@@ -917,9 +917,9 @@ main(int argc, char *argv[])
             regfree(&exclude_re);
 
         if (count) {
-  #ifdef DEBUG
+#ifdef DEBUG
             fprintf(stderr, "- %d interface%s found\n", count, (count==1)?"":"s");
-  #endif
+#endif
         } else {
             printf("- no interfaces matched regex");
             exit (0);

--- a/snmp_bulkget.c
+++ b/snmp_bulkget.c
@@ -132,7 +132,7 @@ main(int argc, char *argv[])
     int     coll_tolerance = -1;
     u64     speed = 0;
     int     bw = 0;
-    size_t  size,size2;
+    size_t  size;
 
     struct ifStruct *interfaces = NULL; /* current interface data */
     struct ifStruct *oldperfdata = NULL; /* previous check interface data */
@@ -146,7 +146,7 @@ main(int argc, char *argv[])
     char *indexes=0;
 #endif /* INDEXES */
 #ifdef HAVE_GETADDRINFO
-    struct addrinfo *addr_list, *addr_listp;
+    struct addrinfo *addr_list;
 #endif /* HAVE_GETADDRINFO */
 
     struct timeval tv;
@@ -905,27 +905,26 @@ main(int argc, char *argv[])
                               (match_aliases_flag && !(regexec(&exclude_re, interfaces[i].alias, (size_t) 0, NULL, 0)));
             } if (status && !status2) {
                 count++;
-#ifdef DEBUG
+  #ifdef DEBUG
                 fprintf(stderr, "Interface %d (%s) matched\n", interfaces[i].index, interfaces[i].descr);
-#endif
+  #endif
             } else
                 interfaces[i].ignore = 1;
         }
         regfree(&re);
 
-    if (exclude_list)
-        regfree(&exclude_re);
+    	if (exclude_list)
+            regfree(&exclude_re);
 
         if (count) {
-#ifdef DEBUG
+  #ifdef DEBUG
             fprintf(stderr, "- %d interface%s found\n", count, (count==1)?"":"s");
-#endif
+  #endif
         } else {
             printf("- no interfaces matched regex");
             exit (0);
-        }
-
-    }
+       		 }
+   	 }
 
 
     /* let the user know about interfaces that are down (and subsequently ignored) */
@@ -1568,7 +1567,7 @@ int parseoids(int i, char *oid_list, struct OIDStruct *query)
 void create_pdu(int mode, char **oidlist, netsnmp_pdu **pdu, struct OIDStruct **oids, int nonrepeaters, long max)
 {
     int i;
-    static char **oid_ifp;
+    //static char **oid_ifp;
 
     if (mode == NONBULK)
         *pdu = snmp_pdu_create(SNMP_MSG_GET);

--- a/snmp_bulkget.c
+++ b/snmp_bulkget.c
@@ -1567,7 +1567,6 @@ int parseoids(int i, char *oid_list, struct OIDStruct *query)
 void create_pdu(int mode, char **oidlist, netsnmp_pdu **pdu, struct OIDStruct **oids, int nonrepeaters, long max)
 {
     int i;
-    //static char **oid_ifp;
 
     if (mode == NONBULK)
         *pdu = snmp_pdu_create(SNMP_MSG_GET);


### PR DESCRIPTION
This commit fixes 5 warnings and one note on the GCC 7.5 Compiler of SLES 15.4 with guarding, indentation and unused variables.