### PR TITLE
Add port option

### DIFF
--- a/snmp_bulkget.h
+++ b/snmp_bulkget.h
@@ -90,6 +90,7 @@ typedef struct configuration_struct {
 	int err_tolerance;
 	int coll_tolerance;
 	char *hostname;
+	char* port;
 	char *user;
 	char *auth_proto;
 	char *auth_pass;


### PR DESCRIPTION
This adds an option to specify a port to use. This is not commonly need (most SNMP agents use 161), but is rather useful for testing.