### PR TITLE
Fix/number of interfaces bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,6 @@ jobs:
     - name: check_interfaces with some cisco stuff
       run: ./check_interfaces -h 127.0.0.1 --port=1611 -c cisco-c3560 -d
 
-    - name: check_interfaces with lying hpe-procurve
-      run: ./check_interfaces -h 127.0.0.1 --port=1611 -c network/switch/hpe-procurve-516733-b21 -d -t 250000
-
-
   clang-build:
     runs-on: ubuntu-latest
     env:
@@ -87,6 +83,3 @@ jobs:
 
     - name: check_interfaces with some cisco stuff
       run: ./check_interfaces -h 127.0.0.1 --port=1611 -c cisco-c3560 -d
-
-    - name: check_interfaces with lying hpe-procurve
-      run: ./check_interfaces -h 127.0.0.1 --port=1611 -c network/switch/hpe-procurve-516733-b21 -d -t 250000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CC: clang
-      CFLAGS: "-Wall -Werror"
+      CFLAGS: "-Wall"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       run: ./check_interfaces -h 127.0.0.1 --port=1611 -c cisco-c3560 -d
 
     - name: check_interfaces with lying hpe-procurve
-      run: ./check_interfaces -h 127.0.0.1 --port=1611 -c network/switch/hpe-procurve-516733-b21 -d
+      run: ./check_interfaces -h 127.0.0.1 --port=1611 -c network/switch/hpe-procurve-516733-b21 -d -t 250000
 
 
   clang-build:
@@ -89,4 +89,4 @@ jobs:
       run: ./check_interfaces -h 127.0.0.1 --port=1611 -c cisco-c3560 -d
 
     - name: check_interfaces with lying hpe-procurve
-      run: ./check_interfaces -h 127.0.0.1 --port=1611 -c network/switch/hpe-procurve-516733-b21 -d
+      run: ./check_interfaces -h 127.0.0.1 --port=1611 -c network/switch/hpe-procurve-516733-b21 -d -t 250000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      CFLAGS: "-Wall" 
+      CFLAGS: "-Wall -Werror"
 
     steps:
     - uses: actions/checkout@v4
- 
+
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
@@ -41,18 +41,22 @@ jobs:
       run: sleep 30s
       shell: bash
 
-    - name: check_interfaces
+    - name: check_interfaces with some cisco stuff
       run: ./check_interfaces -h 127.0.0.1 --port=1611 -c cisco-c3560 -d
+
+    - name: check_interfaces with lying hpe-procurve
+      run: ./check_interfaces -h 127.0.0.1 --port=1611 -c network/switch/hpe-procurve-516733-b21 -d
+
 
   clang-build:
     runs-on: ubuntu-latest
     env:
       CC: clang
-      CFLAGS: "-Wall" 
+      CFLAGS: "-Wall -Werror"
 
     steps:
     - uses: actions/checkout@v4
- 
+
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
@@ -81,5 +85,8 @@ jobs:
       run: sleep 30s
       shell: bash
 
-    - name: check_interfaces
+    - name: check_interfaces with some cisco stuff
       run: ./check_interfaces -h 127.0.0.1 --port=1611 -c cisco-c3560 -d
+
+    - name: check_interfaces with lying hpe-procurve
+      run: ./check_interfaces -h 127.0.0.1 --port=1611 -c network/switch/hpe-procurve-516733-b21 -d

--- a/check_interfaces.c
+++ b/check_interfaces.c
@@ -324,6 +324,18 @@ int main(int argc, char *argv[]) {
 					vars = vars->next_variable;
 				}
 
+				// get the real list length we need
+				int real_count = 0;
+				for (netsnmp_variable_list *runner = response->variables; runner; runner = runner->next_variable) {
+					if (vars->type == ASN_OCTET_STR) {
+						real_count ++;
+					}
+				}
+
+				if (real_count > ifNumber) {
+					ifNumber = real_count;
+				}
+
 				interfaces = (struct ifStruct *)calloc((size_t)ifNumber,
 													   sizeof(struct ifStruct));
 				oldperfdata = (struct ifStruct *)calloc(

--- a/check_interfaces.c
+++ b/check_interfaces.c
@@ -377,15 +377,18 @@ int main(int argc, char *argv[]) {
 				if (vars->type == ASN_OCTET_STR) {
 					if (config.trimdescr && config.trimdescr < vars->val_len) {
 						interfaces[count].index =
-							(int)vars->name[(vars->name_length - 1)];
+							vars->name[(vars->name_length - 1)];
+
 						MEMCPY(interfaces[count].descr,
 							   (vars->val.string) + config.trimdescr,
 							   vars->val_len - config.trimdescr);
+
 						TERMSTR(interfaces[count].descr,
 								vars->val_len - config.trimdescr);
 					} else {
 						interfaces[count].index =
-							(int)vars->name[(vars->name_length - 1)];
+							vars->name[(vars->name_length - 1)];
+
 						MEMCPY(interfaces[count].descr, vars->val.string,
 							   vars->val_len);
 						TERMSTR(interfaces[count].descr, vars->val_len);


### PR DESCRIPTION
This PR changes the computation of number of interfaces of the devices. Sometimes devices seem to report less interfaces than are really visible and `check_interfaces` just allocated memory for the reported number.

Execution of `check_interfaces` was unstable in that case, since some writes then occured beyond the borders of allocated memory.

This could possibly the reason for #4 