### PR TITLE
docs: document the -R/--exclude-regex option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ sudo make install   ## optional
      -r|--regex         interface list regexp
                             Regex to match interfaces (important, this is a Regular Expression
                             not a simple wildcard string, see below)
+     -R|--exclude-regex interface list negative regexp
+                        Interfaces matching this regex are excluded, even if they
+                        also match -r/--regex
      -e|--errors        number of in errors (CRC errors for cisco) to consider a warning (default 50)
                             Only warn if errors increase by more than this amount between checks
      -f|--out-errors    number of out errors (collisions for cisco) to consider a warning


### PR DESCRIPTION
`-R`/`--exclude-regex` has been a working CLI option since it was added
(present in `usage()`'s `--help` output and fully wired up in
`parse_and_check_commandline()`), but it's missing from the README's
option list. This adds the missing entry, matching the wording already
used in the `--help` text.

No code changes, README only.