### PR TITLE
perfdata: add --legacy-perfdata flag and fix plugins= count mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@ sudo make install   ## optional
         --timeout       sets the SNMP timeout (in ms)
      -m|--mode          special operating mode (default,cisco,nonbulk,bintec)
                             Workarounds for various hardware
-
+     --legacy-perfdata  restore the pre-1.4.4 performance data format
+                        Omits checktime=, the ", of which X matched the regex" status
+                        text, and per-interface inBitps/outBitps fields, matching the
+                        exact output of versions before 1.4.4. Use this if you have
+                        existing RRD/PNP4Nagios graph definitions that expect the old
+                        field layout and would otherwise break on upgrade.
 
 ### Modes
 

--- a/check_interfaces.c
+++ b/check_interfaces.c
@@ -81,6 +81,8 @@ static char *oid_vals_cisco[] = {".1.3.6.1.2.1.2.2.1.7",      /* ifAdminStatus *
  */
 static const char *modes[] = {"default", "cisco", "nonbulk", "bintec", NULL};
 
+static bool legacy_perfdata_flag = false;
+
 #ifdef DEBUG
 static char *implode_result;
 #endif
@@ -953,12 +955,18 @@ returncode_t print_output(struct configuration_struct *config, struct ifStruct *
 	}
 
 	/* now print performance data */
-
+	if (legacy_perfdata_flag) {
+		printf("%*s | interfaces::check_multi::plugins=%d time=%.2Lf", (int)out->len,
+			   out->text, number_of_matched_interfaces,
+			   (((long double)time_value->tv_sec + ((long double)time_value->tv_usec / 1000000)) -
+				starttime));
+	} else {
 	printf("%*s | interfaces::check_multi::plugins=%d time=%.2Lf checktime=%ld", (int)out->len,
 		   out->text, number_of_matched_interfaces,
 		   (((long double)time_value->tv_sec + ((long double)time_value->tv_usec / 1000000)) -
 			starttime),
 		   time_value->tv_sec);
+	}
 	if (uptime) {
 		printf(" %sdevice::check_snmp::uptime=%us", config->prefix ? config->prefix : "", uptime);
 	}
@@ -980,8 +988,10 @@ returncode_t print_output(struct configuration_struct *config, struct ifStruct *
 			} else {
 				printf(" %s=%llu", if_vars[8], interfaces[i].speed);
 			}
+			if (!legacy_perfdata_flag) {
 			printf(" %s=%llub %s=%llub", if_vars[9], interfaces[i].inbitps, if_vars[10],
 				   interfaces[i].outbitps);
+			}
 		}
 	}
 	printf("\n%*s", (int)perf.len, perf.text);
@@ -1289,6 +1299,7 @@ void parse_and_check_commandline(int argc, char **argv, struct configuration_str
 									   {"sleep", required_argument, NULL, 3},
 									   {"retries", required_argument, NULL, 4},
 									   {"max-repetitions", required_argument, NULL, 5},
+									   {"legacy-perfdata", no_argument, NULL, 6},
 									   {"version", no_argument, NULL, VERSION_OPTION},
 									   {NULL, 0, NULL, 0}};
 
@@ -1387,6 +1398,9 @@ void parse_and_check_commandline(int argc, char **argv, struct configuration_str
 			break;
 		case 5:
 			config->pdu_max_repetitions = strtol(optarg, NULL, 10);
+			break;
+		case 6:
+			legacy_perfdata_flag = true;
 			break;
 		case VERSION_OPTION:
 			print_version();
@@ -1512,6 +1526,8 @@ int usage(char *progname) {
 	printf("    --retries\t\thow often to retry before giving up\n");
 	printf("    --max-repetitions\t\tsee "
 		   "<http://www.net-snmp.org/docs/man/snmpbulkwalk.html>\n");
+	printf("    --legacy-perfdata\t\tuse the pre-1.4.4 perfdata format "
+		   "(no checktime=, no \", of which X matched\", no inBitps/outBitps)\n");
 	printf("    --port\t\tPort (default 161)\n");
 	printf("    --version\t\tPrint program version\n");
 	printf("\n");

--- a/check_interfaces.c
+++ b/check_interfaces.c
@@ -733,6 +733,14 @@ returncode_t print_output(struct configuration_struct *config, struct ifStruct *
 
 	unsigned int parsed_lastcheck = 0;
 
+	unsigned int printed_count = 0;
+
+	for (int i = 0; i < ifNumber; i++) {
+		if (!interfaces[i].ignore && (!interfaces[i].admin_down || config->print_all_flag)) {
+			printed_count++;
+		}
+	}
+
 	if (config->oldperfdatap && config->oldperfdatap[0]) {
 		parse_perfdata(config->oldperfdatap, oldperfdata, config->prefix, &parsed_lastcheck,
 					   ifNumber, if_vars);
@@ -957,12 +965,12 @@ returncode_t print_output(struct configuration_struct *config, struct ifStruct *
 	/* now print performance data */
 	if (legacy_perfdata_flag) {
 		printf("%*s | interfaces::check_multi::plugins=%d time=%.2Lf", (int)out->len,
-			   out->text, number_of_matched_interfaces,
+			   out->text, printed_count,
 			   (((long double)time_value->tv_sec + ((long double)time_value->tv_usec / 1000000)) -
 				starttime));
 	} else {
 	printf("%*s | interfaces::check_multi::plugins=%d time=%.2Lf checktime=%ld", (int)out->len,
-		   out->text, number_of_matched_interfaces,
+		   out->text, printed_count,
 		   (((long double)time_value->tv_sec + ((long double)time_value->tv_usec / 1000000)) -
 			starttime),
 		   time_value->tv_sec);


### PR DESCRIPTION
## Summary

Two related fixes around the perfdata/check_multi output:

1. An opt-in `--legacy-perfdata` flag that restores the exact pre-1.4.4
   performance data format, for users with existing RRD/PNP4Nagios graph
   definitions that broke on upgrade.
2. A `plugins=` count fix, independent of the flag, that corrects a
   mismatch between the advertised and actual number of perfdata blocks.

## Background

v1.4.4 changed the perfdata output under the label "general linter and
style fixes":
- added `checktime=<unixtime>` to the `check_multi` header
- added `inBitps=`/`outBitps=` per interface

This silently broke existing RRD definitions that parse the perfdata by
fixed field layout, since new fields shifted/extended what downstream
tools expect.

## Change 1: `--legacy-perfdata` flag

Restores the exact pre-1.4.4 output when passed:
- no `checktime=`
- no `inBitps=`/`outBitps=` fields

Without the flag, behavior is unchanged from current `master`.

## Change 2: `plugins=` count fix

`plugins=` in the `check_multi` header used
`number_of_matched_interfaces` (how many interfaces matched the regex),
but the loop that prints `check_snmp` blocks below only emits a block
for interfaces that are neither ignored nor administratively down.

Example from a real device: 44 interfaces matched the regex, 40 of
them administratively down → only 4 `::check_snmp::` blocks are
actually printed, but the header said `plugins=44`. This mismatch can
confuse RRD/`check_multi` consumers that rely on this count to know how
many data sources to expect.

`plugins=` now reflects the number of blocks actually printed, in both
the default and `--legacy-perfdata` output. The `, of which X matched
the regex` status text is unaffected by this fix, since that's meant to
report the raw regex match count regardless of admin-down status - it's
purely informational (appears before the `|`, not parsed by RRD tools).

## Testing

Verified on a real Ekinops router with 44 regex-matched interfaces (40
administratively down). 